### PR TITLE
Update the link to BCP 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository contains tests to validate the implementations of the W3C's MiniApp specifications, specifically [MiniApp Packaging](https://www.w3.org/TR/miniapp-packaging/) (the spec for the MiniApp format itself), [MiniApp Manifest](https://www.w3.org/TR/miniapp-manifest/) (the spec to define a MiniApp and its configuration), and [MiniApp Lifecycle](https://www.w3.org/TR/miniapp-lifecycle/) (the spec that defines the events and APIs to control the execution lifecycle of a MiniApp). Our
 objective is to test every normative statement (that is, every
-[`MUST` or `SHOULD` or `MAY`](https://datatracker.ietf.org/doc/html/bcp14), etc.).
+[`MUST` or `SHOULD` or `MAY`](https://www.rfc-editor.org/info/bcp14), etc.).
 
 The [test reports](https://w3c.github.io/miniapp-tests/) describe all the tests, including
 [implementation results](https://w3c.github.io/miniapp-tests/results) and


### PR DESCRIPTION
AFAIK rfc-editor.org is the recommended URL for RFC and BCP documents nowadays.