### PR TITLE
Update the license

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "git+https://github.com/w3c/miniapp-tests.git"
   },
   "author": "Ivan Herman, Dan Lazin, Martin Alvarez",
-  "license": "ISC",
+  "license": "W3C-20150513",
   "bugs": {
     "url": "https://github.com/w3c/miniapp-tests/issues"
   },


### PR DESCRIPTION
Use [W3C-20150513](https://spdx.org/licenses/W3C-20150513.html) instead of `ISC`.